### PR TITLE
Allow for using an (inline) key instead of password

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,5 +29,5 @@ Do not keep your authentication password in HCL for production environments, use
 - **port** (Integer, Optional) Jumpost's port (defaults to `22`)
 - **username** (String, Optional) Username to authenticate to the jumphost (in future it will try to guess from ssh config)
 - **password** (String, Optional) Password to authenticate to the jumphost
-- **key** (String, Optional) Private key to authenticate to the jumphost
+- **private_key** (String, Optional) Private key to authenticate to the jumphost
 - **useAgent** (Bool, Optional) Use the SSH Agent to authenticate to the jumphost

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,4 +28,6 @@ Do not keep your authentication password in HCL for production environments, use
 - **hostname** (String, Optional) Jumphost's hostname (defaults to `localhost`)
 - **port** (Integer, Optional) Jumpost's port (defaults to `22`)
 - **username** (String, Optional) Username to authenticate to the jumphost (in future it will try to guess from ssh config)
-- **password** (String, Optional) Password to authenticate to the jumphost (can fallback to ssh agent)
+- **password** (String, Optional) Password to authenticate to the jumphost
+- **key** (String, Optional) Private key to authenticate to the jumphost
+- **useAgent** (Bool, Optional) Use the SSH Agent to authenticate to the jumphost

--- a/jumphost/data_source_ssh_test.go
+++ b/jumphost/data_source_ssh_test.go
@@ -3,16 +3,26 @@ package jumphost
 import (
 	"bytes"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 const (
-	httpServerDataSource = `
+	key = `-----BEGIN OPENSSH PRIVATE KEY-----
+b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
+QyNTUxOQAAACDuzSye5Tr7FcwyuEm5oDF15DWuUlkHPQsU0VJq9um3+QAAAJBjJvpdYyb6
+XQAAAAtzc2gtZWQyNTUxOQAAACDuzSye5Tr7FcwyuEm5oDF15DWuUlkHPQsU0VJq9um3+Q
+AAAEBaDLAdQm00RB4AGO5/uCoTCZsQaHwBvPK+czoQabv2su7NLJ7lOvsVzDK4SbmgMXXk
+Na5SWQc9CxTRUmr26bf5AAAAC3Rlc3RzQGxvY2FsAQI=
+-----END OPENSSH PRIVATE KEY-----
+`
+
+	httpServerDataSourcePassword = `
 	data jumphost_ssh "http_server" {
 		hostname = "web"
 		port = 8080
@@ -28,20 +38,68 @@ const (
 		password = "1234"
 	}
 	`
+
+	httpServerDataSourcePublicKey = `
+	data jumphost_ssh "http_server" {
+		hostname = "web"
+		port = 8080
+	}
+
+	output local_port {
+		value = data.jumphost_ssh.http_server.local_port
+	}
+
+	provider jumphost {
+		port = %d
+		username = "terraform"
+		key = <<EOT
+%s
+EOT
+	}
+	`
 )
 
 func init() {
 	composeUp()
 }
 
-func TestSingleConnection(t *testing.T) {
+func TestSingleConnectionUsingPassword(t *testing.T) {
 	resourceName := "data.jumphost_ssh.http_server"
 	resource.UnitTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
 				ResourceName: resourceName,
-				Config:       fmt.Sprintf(httpServerDataSource, sshPort),
+				Config:       fmt.Sprintf(httpServerDataSourcePassword, sshPort),
+				Check: func(s *terraform.State) error {
+					r := s.RootModule()
+					localPort := r.Outputs["local_port"].Value.(string)
+					address := fmt.Sprintf("http://localhost:%s/status/418", localPort)
+					response, err := http.Get(address)
+					if err != nil {
+						t.Fatalf("failed to call forwarded service %s", err)
+					}
+					assert.Equal(t, response.StatusCode, 418)
+					var output bytes.Buffer
+					_, err = output.ReadFrom(response.Body)
+					if err != nil {
+						t.Fatalf("failed to read service's response %s", err)
+					}
+					assert.Equal(t, output.String(), "I'm a teapot!")
+					return nil
+				},
+			},
+		},
+	})
+}
+func TestSingleConnectionUsingPublicKey(t *testing.T) {
+	resourceName := "data.jumphost_ssh.http_server"
+	resource.UnitTest(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				ResourceName: resourceName,
+				Config:       fmt.Sprintf(httpServerDataSourcePublicKey, sshPort, key),
 				Check: func(s *terraform.State) error {
 					r := s.RootModule()
 					localPort := r.Outputs["local_port"].Value.(string)

--- a/jumphost/data_source_ssh_test.go
+++ b/jumphost/data_source_ssh_test.go
@@ -77,13 +77,13 @@ func TestSingleConnectionUsingPassword(t *testing.T) {
 					address := fmt.Sprintf("http://localhost:%s/status/418", localPort)
 					response, err := http.Get(address)
 					if err != nil {
-						t.Fatalf("failed to call forwarded service %s", err)
+						t.Fatalf("failed to call forwarded service %v", err)
 					}
 					assert.Equal(t, response.StatusCode, 418)
 					var output bytes.Buffer
 					_, err = output.ReadFrom(response.Body)
 					if err != nil {
-						t.Fatalf("failed to read service's response %s", err)
+						t.Fatalf("failed to read service's response %v", err)
 					}
 					assert.Equal(t, output.String(), "I'm a teapot!")
 					return nil
@@ -92,6 +92,7 @@ func TestSingleConnectionUsingPassword(t *testing.T) {
 		},
 	})
 }
+
 func TestSingleConnectionUsingPublicKey(t *testing.T) {
 	resourceName := "data.jumphost_ssh.http_server"
 	resource.UnitTest(t, resource.TestCase{
@@ -106,13 +107,13 @@ func TestSingleConnectionUsingPublicKey(t *testing.T) {
 					address := fmt.Sprintf("http://localhost:%s/status/418", localPort)
 					response, err := http.Get(address)
 					if err != nil {
-						t.Fatalf("failed to call forwarded service %s", err)
+						t.Fatalf("failed to call forwarded service %v", err)
 					}
 					assert.Equal(t, response.StatusCode, 418)
 					var output bytes.Buffer
 					_, err = output.ReadFrom(response.Body)
 					if err != nil {
-						t.Fatalf("failed to read service's response %s", err)
+						t.Fatalf("failed to read service's response %v", err)
 					}
 					assert.Equal(t, output.String(), "I'm a teapot!")
 					return nil

--- a/jumphost/data_source_ssh_test.go
+++ b/jumphost/data_source_ssh_test.go
@@ -52,7 +52,7 @@ Na5SWQc9CxTRUmr26bf5AAAAC3Rlc3RzQGxvY2FsAQI=
 	provider jumphost {
 		port = %d
 		username = "terraform"
-		key = <<EOT
+		private_key = <<EOT
 %s
 EOT
 	}

--- a/jumphost/provider.go
+++ b/jumphost/provider.go
@@ -2,9 +2,10 @@ package jumphost
 
 import (
 	"context"
+	"sync"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"sync"
 )
 
 const (
@@ -12,6 +13,8 @@ const (
 	portAttr     = "port"
 	usernameAttr = "username"
 	passwordAttr = "password"
+	keyPairAttr  = "key"
+	agentAttr    = "use_agent"
 )
 
 var (
@@ -42,6 +45,15 @@ func Provider() *schema.Provider {
 				Optional:  true,
 				Sensitive: true,
 			},
+			keyPairAttr: {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+			agentAttr: {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"jumphost_ssh": dataSourceSsh(),
@@ -59,6 +71,8 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		d.Get(hostNameAttr).(string),
 		d.Get(usernameAttr).(string),
 		d.Get(passwordAttr).(string),
+		d.Get(keyPairAttr).(string),
+		d.Get(agentAttr).(bool),
 		port,
 	)
 	return &client, diags

--- a/jumphost/provider.go
+++ b/jumphost/provider.go
@@ -9,12 +9,12 @@ import (
 )
 
 const (
-	hostNameAttr = "hostname"
-	portAttr     = "port"
-	usernameAttr = "username"
-	passwordAttr = "password"
-	keyPairAttr  = "key"
-	agentAttr    = "use_agent"
+	hostNameAttr   = "hostname"
+	portAttr       = "port"
+	usernameAttr   = "username"
+	passwordAttr   = "password"
+	privatekeyAttr = "private_key"
+	useAgentAttr   = "use_agent"
 )
 
 var (
@@ -45,14 +45,15 @@ func Provider() *schema.Provider {
 				Optional:  true,
 				Sensitive: true,
 			},
-			keyPairAttr: {
+			privatekeyAttr: {
 				Type:      schema.TypeString,
 				Optional:  true,
 				Sensitive: true,
 			},
-			agentAttr: {
+			useAgentAttr: {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  true,
 			},
 		},
 		DataSourcesMap: map[string]*schema.Resource{
@@ -71,8 +72,8 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		d.Get(hostNameAttr).(string),
 		d.Get(usernameAttr).(string),
 		d.Get(passwordAttr).(string),
-		d.Get(keyPairAttr).(string),
-		d.Get(agentAttr).(bool),
+		d.Get(privatekeyAttr).(string),
+		d.Get(useAgentAttr).(bool),
 		port,
 	)
 	return &client, diags

--- a/jumphost/provider.go
+++ b/jumphost/provider.go
@@ -13,7 +13,7 @@ const (
 	portAttr       = "port"
 	usernameAttr   = "username"
 	passwordAttr   = "password"
-	privatekeyAttr = "private_key"
+	privateKeyAttr = "private_key"
 	useAgentAttr   = "use_agent"
 )
 
@@ -45,7 +45,7 @@ func Provider() *schema.Provider {
 				Optional:  true,
 				Sensitive: true,
 			},
-			privatekeyAttr: {
+			privateKeyAttr: {
 				Type:      schema.TypeString,
 				Optional:  true,
 				Sensitive: true,
@@ -72,7 +72,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		d.Get(hostNameAttr).(string),
 		d.Get(usernameAttr).(string),
 		d.Get(passwordAttr).(string),
-		d.Get(privatekeyAttr).(string),
+		d.Get(privateKeyAttr).(string),
 		d.Get(useAgentAttr).(bool),
 		port,
 	)

--- a/jumphost/ssh.go
+++ b/jumphost/ssh.go
@@ -31,7 +31,7 @@ type SshTunnel struct {
 	ctx       context.Context
 }
 
-func NewSshClient(hostname, username, password string, keyPair string, useAgent bool, port int) SshClient {
+func NewSshClient(hostname, username, password, privateKey string, useAgent bool, port int) SshClient {
 	authenticationMethods := make([]ssh.AuthMethod, 0)
 	if password != "" {
 		authenticationMethods = append(authenticationMethods, ssh.Password(password))
@@ -40,17 +40,17 @@ func NewSshClient(hostname, username, password string, keyPair string, useAgent 
 	if useAgent {
 		agentConn, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK"))
 		if err != nil {
-			log.Printf("Failed to connect to ssh-agent: %s", err)
+			log.Printf("failed to connect to ssh-agent: %v", err)
 		} else {
 			client := agent.NewClient(agentConn)
 			authenticationMethods = append(authenticationMethods, ssh.PublicKeysCallback(client.Signers))
 		}
 	}
 
-	if keyPair != "" {
-		signer, err := ssh.ParsePrivateKey([]byte(keyPair))
+	if privateKey != "" {
+		signer, err := ssh.ParsePrivateKey([]byte(privateKey))
 		if err != nil {
-			log.Printf("Failed to parse private key: %s", err)
+			log.Printf("failed to parse private key: %v", err)
 		} else {
 			log.Printf("Successfully parsed private key: %s", signer.PublicKey().Marshal())
 			authenticationMethods = append(authenticationMethods, ssh.PublicKeys(signer))


### PR DESCRIPTION
Thanks for the groundwork for this Terraform provider.

This PR adds support for using a private key to connect to the jumphost, instead of a password. Not every host running Terraform has the SSH agent running with the necessary keys. Instead you can now use a key from a file, or inline.
